### PR TITLE
feat(order): 주문 배송비 정책 구현

### DIFF
--- a/src/main/java/com/musinsa/orders/domain/Money.java
+++ b/src/main/java/com/musinsa/orders/domain/Money.java
@@ -1,7 +1,6 @@
 package com.musinsa.orders.domain;
 
 import java.util.Objects;
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -21,6 +20,10 @@ public class Money {
       throw new IllegalArgumentException();
     }
     this.amount = amount;
+  }
+
+  public Money plus(Money amount) {
+    return new Money(this.amount + amount.amount);
   }
 
   @Override

--- a/src/main/java/com/musinsa/orders/domain/Money.java
+++ b/src/main/java/com/musinsa/orders/domain/Money.java
@@ -8,16 +8,15 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-public class Price {
+public class Money {
 
-  @Column(name = "price", nullable = false)
   private long amount;
 
-  public static Price from(long amount) {
-    return new Price(amount);
+  public static Money from(long amount) {
+    return new Money(amount);
   }
 
-  private Price(long amount) {
+  private Money(long amount) {
     if (amount < 0) {
       throw new IllegalArgumentException();
     }
@@ -32,7 +31,7 @@ public class Price {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Price price = (Price) o;
+    Money price = (Money) o;
     return Objects.equals(amount, price.amount);
   }
 

--- a/src/main/java/com/musinsa/orders/domain/Money.java
+++ b/src/main/java/com/musinsa/orders/domain/Money.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Money {
 
+  public static final Money ZERO = Money.from(0);
+
   private long amount;
 
   public static Money from(long amount) {
@@ -24,6 +26,10 @@ public class Money {
 
   public Money plus(Money amount) {
     return new Money(this.amount + amount.amount);
+  }
+
+  public boolean isGreaterThanOrEqual(Money other) {
+    return amount >= other.amount;
   }
 
   @Override

--- a/src/main/java/com/musinsa/orders/domain/Order.java
+++ b/src/main/java/com/musinsa/orders/domain/Order.java
@@ -35,4 +35,8 @@ public class Order {
   public List<OrderLineItem> orderLineItems() {
     return Collections.unmodifiableList(orderLineItems.orderLineItems());
   }
+
+  public Money calculateTotalAmount() {
+    return orderLineItems.calculateTotalAmount();
+  }
 }

--- a/src/main/java/com/musinsa/orders/domain/Order.java
+++ b/src/main/java/com/musinsa/orders/domain/Order.java
@@ -2,6 +2,7 @@ package com.musinsa.orders.domain;
 
 import java.util.Collections;
 import java.util.List;
+import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -19,17 +20,22 @@ public class Order {
   @Embedded
   private OrderLineItems orderLineItems;
 
+  @Embedded
+  @AttributeOverride(name = "amount", column = @Column(name = "shipping_fee", nullable = false))
+  private Money shippingFee;
+
   protected Order() {
 
   }
 
-  public Order(List<OrderLineItem> orderLineItems) {
-    this(null, orderLineItems);
+  public Order(List<OrderLineItem> orderLineItems, ShippingFeePolicy shippingFeePolicy) {
+    this(null, orderLineItems, shippingFeePolicy);
   }
 
-  public Order(Long id, List<OrderLineItem> orderLineItems) {
+  public Order(Long id, List<OrderLineItem> orderLineItems, ShippingFeePolicy shippingFeePolicy) {
     this.id = id;
     this.orderLineItems = new OrderLineItems(orderLineItems);
+    this.shippingFee = shippingFeePolicy.calculateShippingFee(this);
   }
 
   public List<OrderLineItem> orderLineItems() {
@@ -38,5 +44,9 @@ public class Order {
 
   public Money calculateTotalAmount() {
     return orderLineItems.calculateTotalAmount();
+  }
+
+  public Money shippingFee() {
+    return shippingFee;
   }
 }

--- a/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
+++ b/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
@@ -1,7 +1,6 @@
 package com.musinsa.orders.domain;
 
 import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;

--- a/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
+++ b/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
@@ -42,4 +42,7 @@ public class OrderLineItem {
     this.price = Money.from(price);
   }
 
+  public Money price() {
+    return price;
+  }
 }

--- a/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
+++ b/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
@@ -1,5 +1,8 @@
 package com.musinsa.orders.domain;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -21,7 +24,8 @@ public class OrderLineItem {
   private ProductName name;
 
   @Embedded
-  private Price price;
+  @AttributeOverride(name = "amount", column = @Column(name = "price", nullable = false))
+  private Money price;
 
   protected OrderLineItem() {
 
@@ -35,7 +39,7 @@ public class OrderLineItem {
     this.id = id;
     this.productId = productId;
     this.name = ProductName.from(name);
-    this.price = Price.from(price);
+    this.price = Money.from(price);
   }
 
 }

--- a/src/main/java/com/musinsa/orders/domain/OrderLineItems.java
+++ b/src/main/java/com/musinsa/orders/domain/OrderLineItems.java
@@ -30,6 +30,12 @@ public class OrderLineItems {
     this.orderLineItems = orderLineItems;
   }
 
+  public Money calculateTotalAmount() {
+    return orderLineItems.stream()
+        .map(OrderLineItem::price)
+        .reduce(Money.ZERO, Money::plus);
+  }
+
   public List<OrderLineItem> orderLineItems() {
     return Collections.unmodifiableList(orderLineItems);
   }

--- a/src/main/java/com/musinsa/orders/domain/ShippingFeePolicy.java
+++ b/src/main/java/com/musinsa/orders/domain/ShippingFeePolicy.java
@@ -1,0 +1,6 @@
+package com.musinsa.orders.domain;
+
+public interface ShippingFeePolicy {
+
+  Money calculateShippingFee(Order order);
+}

--- a/src/main/java/com/musinsa/orders/infra/AmountShippingFeePolicy.java
+++ b/src/main/java/com/musinsa/orders/infra/AmountShippingFeePolicy.java
@@ -1,0 +1,21 @@
+package com.musinsa.orders.infra;
+
+import com.musinsa.orders.domain.Money;
+import com.musinsa.orders.domain.Order;
+import com.musinsa.orders.domain.ShippingFeePolicy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AmountShippingFeePolicy implements ShippingFeePolicy {
+
+  private static final Money FREE_SHIPPING_BASE_AMOUNT = Money.from(50_000L);
+  private static final Money SHIPPING_FEE = Money.from(2_500L);
+
+  @Override
+  public Money calculateShippingFee(Order order) {
+    if (order.calculateTotalAmount().isGreaterThanOrEqual(FREE_SHIPPING_BASE_AMOUNT)) {
+      return Money.ZERO;
+    }
+    return SHIPPING_FEE;
+  }
+}

--- a/src/main/java/com/musinsa/orders/infra/JpaOrderRepository.java
+++ b/src/main/java/com/musinsa/orders/infra/JpaOrderRepository.java
@@ -2,8 +2,8 @@ package com.musinsa.orders.infra;
 
 import com.musinsa.orders.domain.Order;
 import com.musinsa.orders.domain.OrderRepository;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaOrderRepository extends OrderRepository, JpaRepository<Order, Long> {
+
 }

--- a/src/test/java/com/musinsa/orders/Fixtures.java
+++ b/src/test/java/com/musinsa/orders/Fixtures.java
@@ -2,19 +2,39 @@ package com.musinsa.orders;
 
 import com.musinsa.orders.domain.Order;
 import com.musinsa.orders.domain.OrderLineItem;
+import com.musinsa.orders.domain.ShippingFeePolicy;
+import com.musinsa.orders.infra.AmountShippingFeePolicy;
 import java.util.List;
 import java.util.Random;
 
 public class Fixtures {
 
-  public static Order createOrder(List<OrderLineItem> orderLineItems) {
-    return createOrder(new Random().nextLong(), orderLineItems);
+  public static Order createOrder(
+      List<OrderLineItem> orderLineItems
+  ) {
+    return createOrder(new Random().nextLong(), orderLineItems, new AmountShippingFeePolicy());
   }
 
-  public static Order createOrder(long id, List<OrderLineItem> orderLineItems) {
+  public static Order createOrder(
+      Long id,
+      List<OrderLineItem> orderLineItems
+  ) {
+    return createOrder(
+        id,
+        orderLineItems,
+        new AmountShippingFeePolicy()
+    );
+  }
+
+  public static Order createOrder(
+      Long id,
+      List<OrderLineItem> orderLineItems,
+      ShippingFeePolicy shippingFeePolicy
+  ) {
     return new Order(
         id,
-        orderLineItems
+        orderLineItems,
+        shippingFeePolicy
     );
   }
 

--- a/src/test/java/com/musinsa/orders/domain/MoneyTest.java
+++ b/src/test/java/com/musinsa/orders/domain/MoneyTest.java
@@ -8,21 +8,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class PriceTest {
+class MoneyTest {
 
   @ParameterizedTest
   @DisplayName("가격을 생성할 수 있다.")
   @ValueSource(longs = {0, 19_000L})
   void createPrice(long value) {
-    Price actual = Price.from(value);
-    assertThat(actual).isEqualTo(Price.from(value));
+    Money actual = Money.from(value);
+    assertThat(actual).isEqualTo(Money.from(value));
   }
 
   @Test
   @DisplayName("가격은 0원 이상이어야 한다.")
   void createPrice_IllegalArgumentException() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> Price.from(-1));
+        .isThrownBy(() -> Money.from(-1));
   }
 
 }

--- a/src/test/java/com/musinsa/orders/domain/OrderTest.java
+++ b/src/test/java/com/musinsa/orders/domain/OrderTest.java
@@ -24,9 +24,9 @@ class OrderTest {
     assertThat(actual.orderLineItems()).hasSize(3);
     assertThat(actual.orderLineItems()).extracting("productId", "name", "price")
         .contains(
-            tuple(1L, ProductName.from("신발A"), Price.from(15_000L)),
-            tuple(2L, ProductName.from("신발B"), Price.from(16_000L)),
-            tuple(3L, ProductName.from("신발C"), Price.from(17_000L))
+            tuple(1L, ProductName.from("신발A"), Money.from(15_000L)),
+            tuple(2L, ProductName.from("신발B"), Money.from(16_000L)),
+            tuple(3L, ProductName.from("신발C"), Money.from(17_000L))
         );
   }
 

--- a/src/test/java/com/musinsa/orders/domain/OrderTest.java
+++ b/src/test/java/com/musinsa/orders/domain/OrderTest.java
@@ -5,11 +5,20 @@ import static com.musinsa.orders.Fixtures.createOrderLineItem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import com.musinsa.orders.infra.AmountShippingFeePolicy;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class OrderTest {
+
+  private ShippingFeePolicy shippingFeePolicy;
+
+  @BeforeEach
+  void setUp() {
+    shippingFeePolicy = new AmountShippingFeePolicy();
+  }
 
   @Test
   @DisplayName("주문생성")
@@ -18,10 +27,11 @@ class OrderTest {
         createOrderLineItem(1L, "신발A", 15_000L),
         createOrderLineItem(2L, "신발B", 16_000L),
         createOrderLineItem(3L, "신발C", 17_000L)
-    ));
+    ), shippingFeePolicy);
 
     assertThat(actual).isNotNull();
     assertThat(actual.orderLineItems()).hasSize(3);
+    assertThat(actual.shippingFee()).isEqualTo(Money.from(2_500L));
     assertThat(actual.orderLineItems()).extracting("productId", "name", "price")
         .contains(
             tuple(1L, ProductName.from("신발A"), Money.from(15_000L)),

--- a/src/test/java/com/musinsa/orders/domain/ShippingFeePolicyTest.java
+++ b/src/test/java/com/musinsa/orders/domain/ShippingFeePolicyTest.java
@@ -1,0 +1,47 @@
+package com.musinsa.orders.domain;
+
+import static com.musinsa.orders.Fixtures.createOrder;
+import static com.musinsa.orders.Fixtures.createOrderLineItem;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.musinsa.orders.infra.AmountShippingFeePolicy;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ShippingFeePolicyTest {
+
+  private ShippingFeePolicy shippingFeePolicy;
+
+  @BeforeEach
+  void setUp() {
+    shippingFeePolicy = new AmountShippingFeePolicy();
+  }
+
+  @DisplayName("5만원 미만 주문금액에 대해 유료 배송비 2500원을 반환한다")
+  @Test
+  void calculateShippingFee() {
+    Order order = createOrder(1L, List.of(
+        createOrderLineItem(1L, "신발A", 15_000L),
+        createOrderLineItem(2L, "신발B", 16_000L),
+        createOrderLineItem(3L, "신발C", 17_000L)
+    ));
+
+    Money actual = shippingFeePolicy.calculateShippingFee(order);
+    assertThat(actual).isEqualTo(Money.from(2_500L));
+  }
+
+  @DisplayName("5만원 이상 주문금액에 대해 배송비 0원(무료배송금액)을 반환한다")
+  @Test
+  void calculateShippingFee_Free() {
+    Order order = createOrder(1L, List.of(
+        createOrderLineItem(1L, "셔츠A", 40_000L),
+        createOrderLineItem(2L, "셔츠B", 50_000L),
+        createOrderLineItem(3L, "셔츠C", 60_000L)
+    ));
+
+    Money actual = shippingFeePolicy.calculateShippingFee(order);
+    assertThat(actual).isEqualTo(Money.ZERO);
+  }
+}


### PR DESCRIPTION
- Price -> Money 값 객체로 대체
- Money 더하기 및 비교 메서드 추가
- 주문 배송비 금액 기준 배송비 정책 구현
- 주문 도메인 배송비 정책 적용
- 불필요한 import 제거