### PR TITLE
feat(exchange): 교환 정책(ExchangePolicy) 도메인 서비스 구현

### DIFF
--- a/src/main/java/com/musinsa/orders/domain/ExchangePolicy.java
+++ b/src/main/java/com/musinsa/orders/domain/ExchangePolicy.java
@@ -1,0 +1,21 @@
+package com.musinsa.orders.domain;
+
+import java.util.List;
+
+public class ExchangePolicy {
+
+  private static final Money RETURN_SHIPPING_FEE = Money.from(5_000L);
+
+  public Money calculateReturnShippingFee(Order order, List<Long> returnLineItemIds) {
+    validateNotExist(order, returnLineItemIds);
+    return RETURN_SHIPPING_FEE;
+  }
+
+  private void validateNotExist(Order order, List<Long> returnLineItemIds) {
+    List<OrderLineItem> returnLineItems = order.getOrderLineItems(returnLineItemIds);
+    if (returnLineItems.size() != returnLineItemIds.size()) {
+      throw new IllegalArgumentException("교환할 주문 상품이 존재하지 않습니다.");
+    }
+  }
+
+}

--- a/src/main/java/com/musinsa/orders/domain/Order.java
+++ b/src/main/java/com/musinsa/orders/domain/Order.java
@@ -49,4 +49,8 @@ public class Order {
   public Money shippingFee() {
     return shippingFee;
   }
+
+  public List<OrderLineItem> getOrderLineItems(List<Long> orderLineItemIds) {
+    return orderLineItems.getOrderLineItems(orderLineItemIds);
+  }
 }

--- a/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
+++ b/src/main/java/com/musinsa/orders/domain/OrderLineItem.java
@@ -1,5 +1,6 @@
 package com.musinsa.orders.domain;
 
+import java.util.Objects;
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -43,5 +44,9 @@ public class OrderLineItem {
 
   public Money price() {
     return price;
+  }
+
+  public Long id() {
+    return id;
   }
 }

--- a/src/main/java/com/musinsa/orders/domain/OrderLineItems.java
+++ b/src/main/java/com/musinsa/orders/domain/OrderLineItems.java
@@ -2,6 +2,7 @@ package com.musinsa.orders.domain;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.ForeignKey;
@@ -39,4 +40,11 @@ public class OrderLineItems {
   public List<OrderLineItem> orderLineItems() {
     return Collections.unmodifiableList(orderLineItems);
   }
+
+  public List<OrderLineItem> getOrderLineItems(List<Long> orderLineItemIds) {
+    return orderLineItems.stream()
+        .filter(orderLineItem -> orderLineItemIds.contains(orderLineItem.id()))
+        .collect(Collectors.toList());
+  }
+
 }

--- a/src/test/java/com/musinsa/orders/Fixtures.java
+++ b/src/test/java/com/musinsa/orders/Fixtures.java
@@ -38,7 +38,10 @@ public class Fixtures {
     );
   }
 
-  public static OrderLineItem createOrderLineItem(long productId, String name, long price) {
-    return new OrderLineItem(new Random().nextLong(), productId, name, price);
+  public static OrderLineItem createOrderLineItem(Long productId, String name, Long price) {
+    return createOrderLineItem(new Random().nextLong(), productId, name, price);
+  }
+  public static OrderLineItem createOrderLineItem(Long id, Long productId, String name, Long price) {
+    return new OrderLineItem(id, productId, name, price);
   }
 }

--- a/src/test/java/com/musinsa/orders/domain/ExchangePolicyTest.java
+++ b/src/test/java/com/musinsa/orders/domain/ExchangePolicyTest.java
@@ -34,4 +34,17 @@ class ExchangePolicyTest {
     assertThat(actual).isEqualTo(Money.from(5_000L));
   }
 
+  @Test
+  @DisplayName("주문 상품이 존재하지 않으면 반품비를 계산할 수 없다")
+  void calculateReturnShippingFee_NotExistLineItem() {
+    Order order = createOrder(1L, List.of(
+        createOrderLineItem(1L, 1L, "신발A", 15_000L),
+        createOrderLineItem(2L, 2L, "신발B", 16_000L),
+        createOrderLineItem(3L, 3L, "신발C", 17_000L)
+    ));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> exchangePolicy.calculateReturnShippingFee(order, List.of(4L)));
+  }
+
 }

--- a/src/test/java/com/musinsa/orders/domain/ExchangePolicyTest.java
+++ b/src/test/java/com/musinsa/orders/domain/ExchangePolicyTest.java
@@ -1,0 +1,37 @@
+package com.musinsa.orders.domain;
+
+import static com.musinsa.orders.Fixtures.createOrder;
+import static com.musinsa.orders.Fixtures.createOrderLineItem;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ExchangePolicyTest {
+
+  private ExchangePolicy exchangePolicy;
+
+  @BeforeEach
+  void setUp() {
+    exchangePolicy = new ExchangePolicy();
+  }
+
+  @Test
+  @DisplayName("주문 상품 교환 반품비 계산 요청에 왕복 반품비 5000원을 반환한다")
+  void calculateReturnShippingFee() {
+    Order order = createOrder(1L, List.of(
+        createOrderLineItem(1L, 1L, "신발A", 15_000L),
+        createOrderLineItem(2L, 2L, "신발B", 16_000L),
+        createOrderLineItem(3L, 3L, "신발C", 17_000L)
+    ));
+
+    Money actual = exchangePolicy.calculateReturnShippingFee(order, List.of(1L));
+    assertThat(actual).isEqualTo(Money.from(5_000L));
+  }
+
+}


### PR DESCRIPTION
- 교환 정책 반품비 계산 메서드 구현
- 주문 상품 교환 반품비 계산 요청에 왕복 반품비 5000원을 반환한다 단위 테스트 작성
- 주문 상품이 존재하지 않으면 반품비를 계산할 수 없다 단위 테스트 작성